### PR TITLE
Remove unused imports to ipdb

### DIFF
--- a/pide/mt/mt_model_conversion.py
+++ b/pide/mt/mt_model_conversion.py
@@ -140,7 +140,6 @@ def convert_3DModel_2_ModEM(file_out, conductivity_array, mesh, starting_index =
 	"""
 	
 	from scipy.interpolate import griddata
-	import ipdb
 	
 	# core_mesh_size = kwargs.pop('core_mesh_size', mesh[0][0][1][0] - mesh[0][0][0][0])
 	num_horiz_bounds = kwargs.pop('num_horiz_bounds', 8)

--- a/pide/utils/utils.py
+++ b/pide/utils/utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import csv
-import ipdb
 
 def _associate_coordinates_(index, x_target, y_target, x_sample, y_sample):
 	


### PR DESCRIPTION
Remove unused imports of `ipdb` in `mt_model_conversion.py` and `utils/utils.py`. `ipdb` is not being used and those imports create errors when trying to import `pide` after installing just the minimum dependencies.

> [!NOTE]
> This PR was opened as part of the JOSS review process: https://github.com/openjournals/joss-reviews/issues/7021
