### PR TITLE
Minor fix to Harmonica BibTeX reference

### DIFF
--- a/docs/paper/paper.bib
+++ b/docs/paper/paper.bib
@@ -53,7 +53,7 @@
   publisher={Oxford University Press}
 }
 @software{fatiando_a_terra_project_2024,
-  author       = {Fatiando a Terra Project and
+  author       = {{Fatiando a Terra Project} and
                   Castro, Yago M. and
                   Esteban, Federico D. and
                   Li, Lu and


### PR DESCRIPTION
Put `Fatiando a Terra Project` inside curly braces so BibTeX doesn't render it as a person name.

> [!NOTE]
> This PR was opened as part of the JOSS review process: https://github.com/openjournals/joss-reviews/issues/7021
