### PR TITLE
Add missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'h5py',
         'harmonica',
         'pyproj',
-        'netCDF4'
+        'netCDF4',
         'psutil',
     ],
     keywords = ['petrophysics', 'geodynamic modelling', 'magnetotelluric', 'electrical conductivity', 'seismic velocity']


### PR DESCRIPTION
That missing comma made installing `pide` with `pip` to fail.

> [!NOTE]
> This PR was opened as part of the JOSS review process: https://github.com/openjournals/joss-reviews/issues/7021